### PR TITLE
Test result formatting update

### DIFF
--- a/lib/mavensmate/ui/templates/unit_test/result.html
+++ b/lib/mavensmate/ui/templates/unit_test/result.html
@@ -2,7 +2,7 @@
 	<div class="alert-message block-message-custom white" style="margin-bottom:0px;padding: 5px;-webkit-border-radius: 4px 4px 0px 0px;">
 			<p style="float:left;"><strong>{{ loop.key }}.cls</strong></p>
 			<p style="float:right;"><strong>{{ res.ExtendedStatus }}&nbsp;tests passed</strong></p>
-		<div style="clear:both;"></div>	
+		<div style="clear:both;"></div>
 	</div>
 	<table class="table table-striped test_result" style="-webkit-border-radius: 0px 0px 4px 4px;">
 		<thead>
@@ -36,7 +36,7 @@
 			{%- endfor %}
 		</tbody>
 	</table>
-{%- endfor %} 
+{%- endfor %}
 
 <div id="class_wrapper">
 	<!-- START CLASS PROCESSING -->
@@ -66,8 +66,8 @@
 
 		</div>
 
-	{%- endfor %} 
-	<!-- END CLASS PROCESSING --> 
+	{%- endfor %}
+	<!-- END CLASS PROCESSING -->
 </div>
 
 <div id="trigger_wrapper">
@@ -98,8 +98,8 @@
 
 		</div>
 
-	{%- endfor %} 
-	<!-- END TRIGGER PROCESSING --> 
+	{%- endfor %}
+	<!-- END TRIGGER PROCESSING -->
 </div>
 
 

--- a/lib/mavensmate/ui/templates/unit_test/result.html
+++ b/lib/mavensmate/ui/templates/unit_test/result.html
@@ -25,11 +25,13 @@
 					</td>
 					<td>
 						{% if test.Message %}
-							{{ test.Message }} 
+							<pre>{{ test.Message }}</pre>
 						{% endif %}
 						{% if test.StackTrace -%}
-							<br/><br/>
-							<span class="label">Stack Trace</span><br/>{{ test.StackTrace }}
+							<span class="label">Stack Trace</span>
+							<br/>
+							<br/>
+							<pre>{{ test.StackTrace }}</pre>
 						{%- endif %}
 					</td>
 				</tr>


### PR DESCRIPTION
Hi,

I added HTML `<pre>` tags around the test result's errors and stack trace so that they would appear in a monospaced font, making it easier to read, select using a mouse, and find errors. I had an issue where two strings in an assertion did not match, but looked the same in the current font. One had an extra space between words, which was not apparent unless shown in the `<pre>` tags.

I updated the `<br>` tags so the spacing between the elements look nice.

I also removed some trailing white spaces in the file.

Let me know if there's anything else I can do to make this a successful PR.

Thanks for an awesome product!

- Adam