### PR TITLE
add support for refreshing and saving CustomMetadata, partial #610

### DIFF
--- a/lib/mavensmate/file.js
+++ b/lib/mavensmate/file.js
@@ -1,5 +1,5 @@
 /**
- * @file Represents an element of Salesforce metadata. 
+ * @file Represents an element of Salesforce metadata.
  * @author Joseph Ferraro <@joeferraro>
  */
 
@@ -47,11 +47,11 @@ var MavensMateFile = function(opts) {
   this.metadataHelper = this.project ? new MetadataHelper({ sfdcClient : this.project.sfdcClient }) : new MetadataHelper();
   if (this.path) {
     this.path = path.normalize(this.path);
-    this.type = this.metadataHelper.getTypeByPath(this.path);   
+    this.type = this.metadataHelper.getTypeByPath(this.path);
     this.basename = path.basename(this.path);
-    this.name = this.basename.split('.')[0];
-    this.folderName = path.basename(path.dirname(this.path));
     this.extension = path.extname(this.path).replace(/./, '');
+    this.name = path.basename(this.basename, '.' + this.extension);
+    this.folderName = path.basename(path.dirname(this.path));
   }
 };
 
@@ -70,7 +70,7 @@ Object.defineProperty(MavensMateFile.prototype, 'isDirectory', {
     if (this.type.xmlName === 'Document') {
       return path.extname(this.path) === ''; //TODO: some documents may not have an extension!
     } else {
-      return path.extname(this.path) === '';      
+      return path.extname(this.path) === '';
     }
   }
 });
@@ -201,7 +201,7 @@ Object.defineProperty(MavensMateFile.prototype, 'lightningType', {
       }  else if (util.endsWith(this.name, 'Renderer')) {
         return 'RENDERER';
       }
-    } 
+    }
   }
 });
 
@@ -274,7 +274,7 @@ Object.defineProperty(MavensMateFile.prototype, 'existsOnFileSystem', {
  * @return {Boolean}
  */
 Object.defineProperty(MavensMateFile.prototype, 'isMetaFile', {
-  get: function() {  
+  get: function() {
     return util.endsWith(this.path, '-meta.xml');
   }
 });
@@ -284,7 +284,7 @@ Object.defineProperty(MavensMateFile.prototype, 'isMetaFile', {
  */
 Object.defineProperty(MavensMateFile.prototype, 'id', {
   get: function() {
-    try {  
+    try {
       if (this.isDirectory) {
         throw new Error('Cannot get server id for directory.');
       } else {
@@ -304,7 +304,7 @@ Object.defineProperty(MavensMateFile.prototype, 'id', {
 
 Object.defineProperty(MavensMateFile.prototype, 'localStoreEntry', {
   get: function() {
-    try {  
+    try {
       if (this.isDirectory || this.isLightningType) {
         throw new Error('Cannot get local store entry for directories or lightning types currently.');
       } else {
@@ -320,7 +320,7 @@ Object.defineProperty(MavensMateFile.prototype, 'serverCopy', {
   get: function() {
     var self = this;
     return new Promise(function(resolve, reject) {
-      try {  
+      try {
         if (self.isDirectory || self.isLightningType) {
           throw new Error('Cannot get server contents for directories or lightning types currently.');
         } else {
@@ -335,7 +335,7 @@ Object.defineProperty(MavensMateFile.prototype, 'serverCopy', {
           var bodyField = (self.type.xmlName === 'ApexPage' || self.type.xmlName === 'ApexComponent') ? 'Markup' : 'Body';
           var soql = 'Select LastModifiedById, LastModifiedDate, LastModifiedBy.Name, '+bodyField+' From '+self.type.xmlName+' Where Name = \''+self.name+'\'';
           self.project.sfdcClient.conn.query(soql, function(err, result) {
-            if (err) { 
+            if (err) {
               logger.debug('could not get server contents: '+err.message);
               return reject(err);
             }
@@ -366,7 +366,7 @@ Object.defineProperty(MavensMateFile.prototype, 'localMembers', {
       contents.push(new MavensMateFile({ path: path.join(self.path, f), project: self.project }));
       if (!path.extname(f)) {
         var subDirectoryFiles = fs.readdirSync(path.join(self.path, f));
-        _.each(subDirectoryFiles, function(sf) {  
+        _.each(subDirectoryFiles, function(sf) {
           contents.push(new MavensMateFile({ path: path.join(self.path, f, sf), project: self.project }));
         });
       }
@@ -481,7 +481,7 @@ MavensMateFile.prototype.renderAndWriteToDisk = function(destination) {
 
         if (self.hasMetaFile) {
           var metaFilePath = path.join(destination, self.type.directoryName, [apiName,self.type.suffix+'-meta.xml'].join('.'));
-          var metaFileBody = swig.renderFile(path.join('templates', 'meta.xml'), { 
+          var metaFileBody = swig.renderFile(path.join('templates', 'meta.xml'), {
             metadata: self,
             apiVersion: config.get('mm_api_version')
           });
@@ -510,7 +510,7 @@ MavensMateFile.prototype.deleteLocally = function() {
     fs.removeSync(this.path+'-meta.xml');
   }
   if (this.existsOnFileSystem) {
-    fs.removeSync(this.path);    
+    fs.removeSync(this.path);
   }
 };
 
@@ -531,7 +531,7 @@ module.exports.getToolingFiles = function(files, exludeToolingMetadata) {
 };
 
 module.exports.getMetadataApiFiles = function(files, exludeToolingMetadata) {
-  return _.filter(files, function(f) { 
+  return _.filter(files, function(f) {
     if (f.isMetaFile) {
       return true;
     } else if (f.classification === types.LIGHTNING_BUNDLE_ITEM) {
@@ -562,20 +562,20 @@ module.exports.createPackageSubscription = function(files, projectPackageXml, ex
           subscription[f.type.xmlName].push(f.packageName);
         }
       } else {
-        subscription[f.type.xmlName] = [ f.packageName ];          
+        subscription[f.type.xmlName] = [ f.packageName ];
       }
     } else if (f.classification === types.METADATA_FOLDER || f.classification === types.METADATA_FOLDER_ITEM) {
       if (subscription[f.type.xmlName]) {
         subscription[f.type.xmlName].push(f.packageName);
       } else {
-        subscription[f.type.xmlName] = [ f.packageName ];          
-      }  
+        subscription[f.type.xmlName] = [ f.packageName ];
+      }
     } else if (f.classification === types.LIGHTNING_BUNDLE) {
       if (subscription[f.type.xmlName]) {
         subscription[f.type.xmlName].push(f.packageName);
       } else {
-        subscription[f.type.xmlName] = [ f.packageName ];          
-      }   
+        subscription[f.type.xmlName] = [ f.packageName ];
+      }
     }
   });
   return subscription;

--- a/lib/mavensmate/metadata.js
+++ b/lib/mavensmate/metadata.js
@@ -68,22 +68,22 @@ MetadataHelper.prototype.getTypeByPath = function(p) {
     return this.getTypeByDirectoryName('aura');
   } else if (path.basename(grandparentPath) === 'aura') {
     return this.getTypeByDirectoryName('aura');
-  } else {    
+  } else {
     var folderBasedTypes = _.where(this.parentTypes, { 'inFolder': true });
 
     // directory handling
     if (!path.extname(p)) {
-      
+
       // foo/bar/src/classes
       var directoryMatch = _.find(this.parentTypes, { 'directoryName': path.basename(p) });
       if (directoryMatch) {
-        return this.getTypeByDirectoryName(path.basename(p)); 
+        return this.getTypeByDirectoryName(path.basename(p));
       }
 
       //foo/bar/src/reports/myreportfolder
       var parentFolderDirectoryMatch = _.find(folderBasedTypes, { 'directoryName': path.basename(parentPath) });
       if (parentFolderDirectoryMatch) {
-        return this.getTypeByDirectoryName(path.basename(parentPath)); 
+        return this.getTypeByDirectoryName(path.basename(parentPath));
       }
     }
 
@@ -93,7 +93,7 @@ MetadataHelper.prototype.getTypeByPath = function(p) {
     } else {
       ext = p.split('.').pop();
     }
-    var typeBySuffix = this.getTypeBySuffix(ext); 
+    var typeBySuffix = this.getTypeBySuffix(ext);
     if (typeBySuffix) {
       return typeBySuffix;
     }
@@ -102,12 +102,12 @@ MetadataHelper.prototype.getTypeByPath = function(p) {
     //foo/bar/src/email/myfolder/foo.email
     var grandparentFolderDirectoryMatch = _.find(folderBasedTypes, { 'directoryName': path.basename(grandparentPath) });
     if (grandparentFolderDirectoryMatch) {
-      return this.getTypeByDirectoryName(path.basename(grandparentPath)); 
+      return this.getTypeByDirectoryName(path.basename(grandparentPath));
     }
 
     // email templates, for example, will have a -meta.xml file that holds folder metadata
     if (util.endsWith(p, '-meta.xml')) {
-      return this.getTypeByDirectoryName(path.basename(parentPath)); 
+      return this.getTypeByDirectoryName(path.basename(parentPath));
     }
   }
 };
@@ -126,12 +126,12 @@ MetadataHelper.prototype.getTypeByXmlName = function(name) {
   if (!type) {
     type = _.find(self.childTypes, function(childType) {
       return childType.xmlName === name;
-    }); 
+    });
   }
   if (!type) {
     type = _.find(self.parentTypes, function(parentType) {
       return parentType.xmlName === name;
-    }); 
+    });
   }
   logger.silly('getting metadata type by name: '+name);
   logger.silly(type);
@@ -178,21 +178,21 @@ MetadataHelper.prototype.getTypeByDirectoryName = function(dirName) {
         type = parentType;
         return false;
       }
-    });  
+    });
   }
   return type;
 };
 
 MetadataHelper.prototype.childTypes = [
     {'xmlName' : 'ActionOverride', 'tagName' : 'actionOverrides', 'parentXmlName' : 'CustomObject' },
-    {'xmlName' : 'CustomField', 'tagName' : 'fields', 'parentXmlName' : 'CustomObject' }, 
+    {'xmlName' : 'CustomField', 'tagName' : 'fields', 'parentXmlName' : 'CustomObject' },
     {'xmlName' : 'BusinessProcess', 'tagName' : 'businessProcesses', 'parentXmlName' : 'CustomObject' },
-    {'xmlName' : 'RecordType', 'tagName' : 'recordTypes', 'parentXmlName' : 'CustomObject' }, 
-    {'xmlName' : 'WebLink', 'tagName' : 'webLinks', 'parentXmlName' : 'CustomObject' }, 
-    {'xmlName' : 'ValidationRule', 'tagName' : 'validationRules', 'parentXmlName' : 'CustomObject' }, 
-    {'xmlName' : 'NamedFilter', 'tagName' : 'namedFilters', 'parentXmlName' : 'CustomObject' }, 
-    {'xmlName' : 'SharingReason', 'tagName' : 'sharingReasons', 'parentXmlName' : 'CustomObject' }, 
-    {'xmlName' : 'ListView', 'tagName' : 'listViews', 'parentXmlName' : 'CustomObject' }, 
+    {'xmlName' : 'RecordType', 'tagName' : 'recordTypes', 'parentXmlName' : 'CustomObject' },
+    {'xmlName' : 'WebLink', 'tagName' : 'webLinks', 'parentXmlName' : 'CustomObject' },
+    {'xmlName' : 'ValidationRule', 'tagName' : 'validationRules', 'parentXmlName' : 'CustomObject' },
+    {'xmlName' : 'NamedFilter', 'tagName' : 'namedFilters', 'parentXmlName' : 'CustomObject' },
+    {'xmlName' : 'SharingReason', 'tagName' : 'sharingReasons', 'parentXmlName' : 'CustomObject' },
+    {'xmlName' : 'ListView', 'tagName' : 'listViews', 'parentXmlName' : 'CustomObject' },
     {'xmlName' : 'FieldSet', 'tagName' : 'fieldSets', 'parentXmlName' : 'CustomObject' },
     {'xmlName' : 'SharingRecalculation', 'tagName' : 'sharingRecalculations', 'parentXmlName' : 'CustomObject' },
     {'xmlName' : 'CompactLayout', 'tagName' : 'compactLayouts', 'parentXmlName' : 'CustomObject' },
@@ -204,7 +204,7 @@ MetadataHelper.prototype.childTypes = [
     {'xmlName' : 'WorkflowTask', 'tagName' : 'tasks', 'parentXmlName' : 'Workflow' },
     {'xmlName' : 'WorkflowOutboundMessage', 'tagName' : 'outboundMessages', 'parentXmlName' : 'Workflow' },
     {'xmlName' : 'WorkflowFieldUpdate', 'tagName' : 'fieldUpdates', 'parentXmlName' : 'Workflow' },
-    {'xmlName' : 'WorkflowRule', 'tagName' : 'rules', 'parentXmlName' : 'Workflow' }, 
+    {'xmlName' : 'WorkflowRule', 'tagName' : 'rules', 'parentXmlName' : 'Workflow' },
     {'xmlName' : 'WorkflowEmailRecipient', 'tagName' : 'emailRecipients', 'parentXmlName' : 'Workflow' },
     {'xmlName' : 'WorkflowTimeTrigger', 'tagName' : 'timeTriggers', 'parentXmlName' : 'Workflow' },
     {'xmlName' : 'WorkflowActionReference', 'tagName' : 'actionReferences', 'parentXmlName' : 'Workflow' }
@@ -212,448 +212,455 @@ MetadataHelper.prototype.childTypes = [
 
 MetadataHelper.prototype.parentTypes = [
     {
-        'directoryName': 'installedPackages', 
-        'inFolder': false, 
-        'metaFile': false, 
-        'suffix': 'installedPackage', 
+        'directoryName': 'customMetadata',
+        'inFolder': false,
+        'metaFile': false,
+        'suffix': 'md',
+        'xmlName': 'CustomMetadata'
+    },
+    {
+        'directoryName': 'installedPackages',
+        'inFolder': false,
+        'metaFile': false,
+        'suffix': 'installedPackage',
         'xmlName': 'InstalledPackage'
-    }, 
+    },
     {
-        'childXmlNames': 'CustomLabel', 
-        'directoryName': 'labels', 
-        'inFolder': false, 
-        'metaFile': false, 
-        'suffix': 'labels', 
+        'childXmlNames': 'CustomLabel',
+        'directoryName': 'labels',
+        'inFolder': false,
+        'metaFile': false,
+        'suffix': 'labels',
         'xmlName': 'CustomLabels'
-    }, 
+    },
     {
-        'directoryName': 'staticresources', 
-        'inFolder': false, 
-        'metaFile': true, 
-        'suffix': 'resource', 
+        'directoryName': 'staticresources',
+        'inFolder': false,
+        'metaFile': true,
+        'suffix': 'resource',
         'xmlName': 'StaticResource'
-    }, 
+    },
     {
-        'directoryName': 'scontrols', 
-        'inFolder': false, 
-        'metaFile': true, 
-        'suffix': 'scf', 
+        'directoryName': 'scontrols',
+        'inFolder': false,
+        'metaFile': true,
+        'suffix': 'scf',
         'xmlName': 'Scontrol'
-    }, 
+    },
     {
-        'directoryName': 'components', 
-        'inFolder': false, 
-        'metaFile': true, 
-        'suffix': 'component', 
+        'directoryName': 'components',
+        'inFolder': false,
+        'metaFile': true,
+        'suffix': 'component',
         'xmlName': 'ApexComponent'
-    }, 
+    },
     {
-        'directoryName': 'pages', 
-        'inFolder': false, 
-        'metaFile': true, 
-        'suffix': 'page', 
+        'directoryName': 'pages',
+        'inFolder': false,
+        'metaFile': true,
+        'suffix': 'page',
         'xmlName': 'ApexPage'
-    }, 
+    },
     {
-        'directoryName': 'queues', 
-        'inFolder': false, 
-        'metaFile': false, 
-        'suffix': 'queue', 
+        'directoryName': 'queues',
+        'inFolder': false,
+        'metaFile': false,
+        'suffix': 'queue',
         'xmlName': 'Queue'
-    }, 
+    },
     {
         'childXmlNames': [
-            'CustomField', 
-            'BusinessProcess', 
-            'CompactLayout', 
-            'RecordType', 
-            'WebLink', 
-            'ValidationRule', 
-            'NamedFilter', 
-            'SharingReason', 
-            'ListView', 
-            'FieldSet', 
+            'CustomField',
+            'BusinessProcess',
+            'CompactLayout',
+            'RecordType',
+            'WebLink',
+            'ValidationRule',
+            'NamedFilter',
+            'SharingReason',
+            'ListView',
+            'FieldSet',
             'ApexTriggerCoupling'
-        ], 
-        'directoryName': 'objects', 
-        'inFolder': false, 
-        'metaFile': false, 
-        'suffix': 'object', 
+        ],
+        'directoryName': 'objects',
+        'inFolder': false,
+        'metaFile': false,
+        'suffix': 'object',
         'xmlName': 'CustomObject'
-    }, 
+    },
     {
-        'directoryName': 'reportTypes', 
-        'inFolder': false, 
-        'metaFile': false, 
-        'suffix': 'reportType', 
+        'directoryName': 'reportTypes',
+        'inFolder': false,
+        'metaFile': false,
+        'suffix': 'reportType',
         'xmlName': 'ReportType'
-    }, 
+    },
     {
-        'directoryName': 'reports', 
-        'inFolder': true, 
-        'metaFile': false, 
-        'suffix': 'report', 
+        'directoryName': 'reports',
+        'inFolder': true,
+        'metaFile': false,
+        'suffix': 'report',
         'xmlName': 'Report'
-    }, 
+    },
     {
-        'directoryName': 'dashboards', 
-        'inFolder': true, 
-        'metaFile': false, 
-        'suffix': 'dashboard', 
+        'directoryName': 'dashboards',
+        'inFolder': true,
+        'metaFile': false,
+        'suffix': 'dashboard',
         'xmlName': 'Dashboard'
-    }, 
+    },
     {
-        'directoryName': 'analyticSnapshots', 
-        'inFolder': false, 
-        'metaFile': false, 
-        'suffix': 'snapshot', 
+        'directoryName': 'analyticSnapshots',
+        'inFolder': false,
+        'metaFile': false,
+        'suffix': 'snapshot',
         'xmlName': 'AnalyticSnapshot'
-    }, 
+    },
     {
-        'directoryName': 'layouts', 
-        'inFolder': false, 
-        'metaFile': false, 
-        'suffix': 'layout', 
+        'directoryName': 'layouts',
+        'inFolder': false,
+        'metaFile': false,
+        'suffix': 'layout',
         'xmlName': 'Layout'
-    }, 
+    },
     {
-        'directoryName': 'portals', 
-        'inFolder': false, 
-        'metaFile': false, 
-        'suffix': 'portal', 
+        'directoryName': 'portals',
+        'inFolder': false,
+        'metaFile': false,
+        'suffix': 'portal',
         'xmlName': 'Portal'
-    }, 
+    },
     {
-        'directoryName': 'documents', 
-        'inFolder': true, 
-        'metaFile': true, 
+        'directoryName': 'documents',
+        'inFolder': true,
+        'metaFile': true,
         'xmlName': 'Document'
-    }, 
+    },
     {
-        'directoryName': 'weblinks', 
-        'inFolder': false, 
-        'metaFile': false, 
-        'suffix': 'weblink', 
+        'directoryName': 'weblinks',
+        'inFolder': false,
+        'metaFile': false,
+        'suffix': 'weblink',
         'xmlName': 'CustomPageWebLink'
-    }, 
+    },
     {
-        'directoryName': 'quickActions', 
-        'inFolder': false, 
-        'metaFile': false, 
-        'suffix': 'quickAction', 
+        'directoryName': 'quickActions',
+        'inFolder': false,
+        'metaFile': false,
+        'suffix': 'quickAction',
         'xmlName': 'QuickAction'
-    }, 
+    },
     {
         'childXmlNames': {
             '@xsi:nil': 'true'
-        }, 
-        'directoryName': 'flexipages', 
-        'inFolder': false, 
-        'metaFile': false, 
-        'suffix': 'flexipage', 
+        },
+        'directoryName': 'flexipages',
+        'inFolder': false,
+        'metaFile': false,
+        'suffix': 'flexipage',
         'xmlName': 'FlexiPage'
-    }, 
+    },
     {
-        'directoryName': 'tabs', 
-        'inFolder': false, 
-        'metaFile': false, 
-        'suffix': 'tab', 
+        'directoryName': 'tabs',
+        'inFolder': false,
+        'metaFile': false,
+        'suffix': 'tab',
         'xmlName': 'CustomTab'
-    }, 
+    },
     {
-        'directoryName': 'customApplicationComponents', 
-        'inFolder': false, 
-        'metaFile': false, 
-        'suffix': 'customApplicationComponent', 
+        'directoryName': 'customApplicationComponents',
+        'inFolder': false,
+        'metaFile': false,
+        'suffix': 'customApplicationComponent',
         'xmlName': 'CustomApplicationComponent'
-    }, 
+    },
     {
-        'directoryName': 'applications', 
-        'inFolder': false, 
-        'metaFile': false, 
-        'suffix': 'app', 
+        'directoryName': 'applications',
+        'inFolder': false,
+        'metaFile': false,
+        'suffix': 'app',
         'xmlName': 'CustomApplication'
-    }, 
+    },
     {
-        'directoryName': 'letterhead', 
-        'inFolder': false, 
-        'metaFile': false, 
-        'suffix': 'letter', 
+        'directoryName': 'letterhead',
+        'inFolder': false,
+        'metaFile': false,
+        'suffix': 'letter',
         'xmlName': 'Letterhead'
-    }, 
+    },
     {
-        'directoryName': 'email', 
-        'inFolder': true, 
-        'metaFile': true, 
-        'suffix': 'email', 
+        'directoryName': 'email',
+        'inFolder': true,
+        'metaFile': true,
+        'suffix': 'email',
         'xmlName': 'EmailTemplate'
-    }, 
+    },
     {
         'childXmlNames': [
-            'WorkflowFieldUpdate', 
-            'WorkflowKnowledgePublish', 
-            'WorkflowQuickCreate', 
-            'WorkflowTask', 
-            'WorkflowChatterPost', 
-            'WorkflowAlert', 
-            'WorkflowSend', 
-            'WorkflowOutboundMessage', 
-            'WorkflowActionFlow', 
-            'WorkflowApex', 
+            'WorkflowFieldUpdate',
+            'WorkflowKnowledgePublish',
+            'WorkflowQuickCreate',
+            'WorkflowTask',
+            'WorkflowChatterPost',
+            'WorkflowAlert',
+            'WorkflowSend',
+            'WorkflowOutboundMessage',
+            'WorkflowActionFlow',
+            'WorkflowApex',
             'WorkflowRule'
-        ], 
-        'directoryName': 'workflows', 
-        'inFolder': false, 
-        'metaFile': false, 
-        'suffix': 'workflow', 
+        ],
+        'directoryName': 'workflows',
+        'inFolder': false,
+        'metaFile': false,
+        'suffix': 'workflow',
         'xmlName': 'Workflow'
-    }, 
+    },
     {
-        'childXmlNames': 'AssignmentRule', 
-        'directoryName': 'assignmentRules', 
-        'inFolder': false, 
-        'metaFile': false, 
-        'suffix': 'assignmentRules', 
+        'childXmlNames': 'AssignmentRule',
+        'directoryName': 'assignmentRules',
+        'inFolder': false,
+        'metaFile': false,
+        'suffix': 'assignmentRules',
         'xmlName': 'AssignmentRules'
-    }, 
+    },
     {
-        'childXmlNames': 'AutoResponseRule', 
-        'directoryName': 'autoResponseRules', 
-        'inFolder': false, 
-        'metaFile': false, 
-        'suffix': 'autoResponseRules', 
+        'childXmlNames': 'AutoResponseRule',
+        'directoryName': 'autoResponseRules',
+        'inFolder': false,
+        'metaFile': false,
+        'suffix': 'autoResponseRules',
         'xmlName': 'AutoResponseRules'
-    }, 
+    },
     {
-        'childXmlNames': 'EscalationRule', 
-        'directoryName': 'escalationRules', 
-        'inFolder': false, 
-        'metaFile': false, 
-        'suffix': 'escalationRules', 
+        'childXmlNames': 'EscalationRule',
+        'directoryName': 'escalationRules',
+        'inFolder': false,
+        'metaFile': false,
+        'suffix': 'escalationRules',
         'xmlName': 'EscalationRules'
-    }, 
+    },
     {
-        'directoryName': 'roles', 
-        'inFolder': false, 
-        'metaFile': false, 
-        'suffix': 'role', 
+        'directoryName': 'roles',
+        'inFolder': false,
+        'metaFile': false,
+        'suffix': 'role',
         'xmlName': 'Role'
-    }, 
+    },
     {
-        'directoryName': 'groups', 
-        'inFolder': false, 
-        'metaFile': false, 
-        'suffix': 'group', 
+        'directoryName': 'groups',
+        'inFolder': false,
+        'metaFile': false,
+        'suffix': 'group',
         'xmlName': 'Group'
-    }, 
+    },
     {
-        'directoryName': 'postTemplates', 
-        'inFolder': false, 
-        'metaFile': false, 
-        'suffix': 'postTemplate', 
+        'directoryName': 'postTemplates',
+        'inFolder': false,
+        'metaFile': false,
+        'suffix': 'postTemplate',
         'xmlName': 'PostTemplate'
-    }, 
+    },
     {
-        'directoryName': 'approvalProcesses', 
-        'inFolder': false, 
-        'metaFile': false, 
-        'suffix': 'approvalProcess', 
+        'directoryName': 'approvalProcesses',
+        'inFolder': false,
+        'metaFile': false,
+        'suffix': 'approvalProcess',
         'xmlName': 'ApprovalProcess'
-    }, 
+    },
     {
-        'directoryName': 'homePageComponents', 
-        'inFolder': false, 
-        'metaFile': false, 
-        'suffix': 'homePageComponent', 
+        'directoryName': 'homePageComponents',
+        'inFolder': false,
+        'metaFile': false,
+        'suffix': 'homePageComponent',
         'xmlName': 'HomePageComponent'
-    }, 
+    },
     {
-        'directoryName': 'homePageLayouts', 
-        'inFolder': false, 
-        'metaFile': false, 
-        'suffix': 'homePageLayout', 
+        'directoryName': 'homePageLayouts',
+        'inFolder': false,
+        'metaFile': false,
+        'suffix': 'homePageLayout',
         'xmlName': 'HomePageLayout'
-    }, 
+    },
     {
-        'directoryName': 'objectTranslations', 
-        'inFolder': false, 
-        'metaFile': false, 
-        'suffix': 'objectTranslation', 
+        'directoryName': 'objectTranslations',
+        'inFolder': false,
+        'metaFile': false,
+        'suffix': 'objectTranslation',
         'xmlName': 'CustomObjectTranslation'
-    }, 
+    },
     {
-        'directoryName': 'flows', 
-        'inFolder': false, 
-        'metaFile': false, 
-        'suffix': 'flow', 
+        'directoryName': 'flows',
+        'inFolder': false,
+        'metaFile': false,
+        'suffix': 'flow',
         'xmlName': 'Flow'
-    }, 
+    },
     {
-        'directoryName': 'classes', 
-        'inFolder': false, 
-        'metaFile': true, 
-        'suffix': 'cls', 
+        'directoryName': 'classes',
+        'inFolder': false,
+        'metaFile': true,
+        'suffix': 'cls',
         'xmlName': 'ApexClass'
-    }, 
+    },
     {
-        'directoryName': 'triggers', 
-        'inFolder': false, 
-        'metaFile': true, 
-        'suffix': 'trigger', 
+        'directoryName': 'triggers',
+        'inFolder': false,
+        'metaFile': true,
+        'suffix': 'trigger',
         'xmlName': 'ApexTrigger'
-    }, 
+    },
     {
-        'directoryName': 'profiles', 
-        'inFolder': false, 
-        'metaFile': false, 
-        'suffix': 'profile', 
+        'directoryName': 'profiles',
+        'inFolder': false,
+        'metaFile': false,
+        'suffix': 'profile',
         'xmlName': 'Profile'
-    }, 
+    },
     {
-        'directoryName': 'permissionsets', 
-        'inFolder': false, 
-        'metaFile': false, 
-        'suffix': 'permissionset', 
+        'directoryName': 'permissionsets',
+        'inFolder': false,
+        'metaFile': false,
+        'suffix': 'permissionset',
         'xmlName': 'PermissionSet'
-    }, 
+    },
     {
-        'directoryName': 'datacategorygroups', 
-        'inFolder': false, 
-        'metaFile': false, 
-        'suffix': 'datacategorygroup', 
+        'directoryName': 'datacategorygroups',
+        'inFolder': false,
+        'metaFile': false,
+        'suffix': 'datacategorygroup',
         'xmlName': 'DataCategoryGroup'
-    }, 
+    },
     {
-        'directoryName': 'remoteSiteSettings', 
-        'inFolder': false, 
-        'metaFile': false, 
-        'suffix': 'remoteSite', 
+        'directoryName': 'remoteSiteSettings',
+        'inFolder': false,
+        'metaFile': false,
+        'suffix': 'remoteSite',
         'xmlName': 'RemoteSiteSetting'
-    }, 
+    },
     {
-        'directoryName': 'authproviders', 
-        'inFolder': false, 
-        'metaFile': false, 
-        'suffix': 'authprovider', 
+        'directoryName': 'authproviders',
+        'inFolder': false,
+        'metaFile': false,
+        'suffix': 'authprovider',
         'xmlName': 'AuthProvider'
-    }, 
+    },
     {
         'childXmlNames': [
-            'LeadOwnerSharingRule', 
+            'LeadOwnerSharingRule',
             'LeadCriteriaBasedSharingRule'
-        ], 
-        'directoryName': 'leadSharingRules', 
-        'inFolder': false, 
-        'metaFile': false, 
-        'suffix': 'sharingRules', 
+        ],
+        'directoryName': 'leadSharingRules',
+        'inFolder': false,
+        'metaFile': false,
+        'suffix': 'sharingRules',
         'xmlName': 'LeadSharingRules'
-    }, 
+    },
     {
         'childXmlNames': [
-            'CampaignOwnerSharingRule', 
+            'CampaignOwnerSharingRule',
             'CampaignCriteriaBasedSharingRule'
-        ], 
-        'directoryName': 'campaignSharingRules', 
-        'inFolder': false, 
-        'metaFile': false, 
-        'suffix': 'sharingRules', 
+        ],
+        'directoryName': 'campaignSharingRules',
+        'inFolder': false,
+        'metaFile': false,
+        'suffix': 'sharingRules',
         'xmlName': 'CampaignSharingRules'
-    }, 
+    },
     {
         'childXmlNames': [
-            'CaseOwnerSharingRule', 
+            'CaseOwnerSharingRule',
             'CaseCriteriaBasedSharingRule'
-        ], 
-        'directoryName': 'caseSharingRules', 
-        'inFolder': false, 
-        'metaFile': false, 
-        'suffix': 'sharingRules', 
+        ],
+        'directoryName': 'caseSharingRules',
+        'inFolder': false,
+        'metaFile': false,
+        'suffix': 'sharingRules',
         'xmlName': 'CaseSharingRules'
-    }, 
+    },
     {
         'childXmlNames': [
-            'ContactOwnerSharingRule', 
+            'ContactOwnerSharingRule',
             'ContactCriteriaBasedSharingRule'
-        ], 
-        'directoryName': 'contactSharingRules', 
-        'inFolder': false, 
-        'metaFile': false, 
-        'suffix': 'sharingRules', 
+        ],
+        'directoryName': 'contactSharingRules',
+        'inFolder': false,
+        'metaFile': false,
+        'suffix': 'sharingRules',
         'xmlName': 'ContactSharingRules'
-    }, 
+    },
     {
         'childXmlNames': [
-            'OpportunityOwnerSharingRule', 
+            'OpportunityOwnerSharingRule',
             'OpportunityCriteriaBasedSharingRule'
-        ], 
-        'directoryName': 'opportunitySharingRules', 
-        'inFolder': false, 
-        'metaFile': false, 
-        'suffix': 'sharingRules', 
+        ],
+        'directoryName': 'opportunitySharingRules',
+        'inFolder': false,
+        'metaFile': false,
+        'suffix': 'sharingRules',
         'xmlName': 'OpportunitySharingRules'
-    }, 
+    },
     {
         'childXmlNames': [
-            'AccountOwnerSharingRule', 
+            'AccountOwnerSharingRule',
             'AccountCriteriaBasedSharingRule'
-        ], 
-        'directoryName': 'accountSharingRules', 
-        'inFolder': false, 
-        'metaFile': false, 
-        'suffix': 'sharingRules', 
+        ],
+        'directoryName': 'accountSharingRules',
+        'inFolder': false,
+        'metaFile': false,
+        'suffix': 'sharingRules',
         'xmlName': 'AccountSharingRules'
-    }, 
+    },
     {
         'childXmlNames': [
-            'CustomObjectOwnerSharingRule', 
+            'CustomObjectOwnerSharingRule',
             'CustomObjectCriteriaBasedSharingRule'
-        ], 
-        'directoryName': 'customObjectSharingRules', 
-        'inFolder': false, 
-        'metaFile': false, 
-        'suffix': 'sharingRules', 
+        ],
+        'directoryName': 'customObjectSharingRules',
+        'inFolder': false,
+        'metaFile': false,
+        'suffix': 'sharingRules',
         'xmlName': 'CustomObjectSharingRules'
-    }, 
+    },
     {
-        'directoryName': 'communities', 
-        'inFolder': false, 
-        'metaFile': false, 
-        'suffix': 'community', 
+        'directoryName': 'communities',
+        'inFolder': false,
+        'metaFile': false,
+        'suffix': 'community',
         'xmlName': 'Community'
-    }, 
+    },
     {
-        'directoryName': 'callCenters', 
-        'inFolder': false, 
-        'metaFile': false, 
-        'suffix': 'callCenter', 
+        'directoryName': 'callCenters',
+        'inFolder': false,
+        'metaFile': false,
+        'suffix': 'callCenter',
         'xmlName': 'CallCenter'
-    }, 
+    },
     {
-        'directoryName': 'connectedApps', 
-        'inFolder': false, 
-        'metaFile': false, 
-        'suffix': 'connectedApp', 
+        'directoryName': 'connectedApps',
+        'inFolder': false,
+        'metaFile': false,
+        'suffix': 'connectedApp',
         'xmlName': 'ConnectedApp'
-    }, 
+    },
     {
-        'directoryName': 'samlssoconfigs', 
-        'inFolder': false, 
-        'metaFile': false, 
-        'suffix': 'samlssoconfig', 
+        'directoryName': 'samlssoconfigs',
+        'inFolder': false,
+        'metaFile': false,
+        'suffix': 'samlssoconfig',
         'xmlName': 'SamlSsoConfig'
-    }, 
+    },
     {
-        'directoryName': 'synonymDictionaries', 
-        'inFolder': false, 
-        'metaFile': false, 
-        'suffix': 'synonymDictionary', 
+        'directoryName': 'synonymDictionaries',
+        'inFolder': false,
+        'metaFile': false,
+        'suffix': 'synonymDictionary',
         'xmlName': 'SynonymDictionary'
-    }, 
+    },
     {
-        'directoryName': 'settings', 
-        'inFolder': false, 
-        'metaFile': false, 
-        'suffix': 'settings', 
+        'directoryName': 'settings',
+        'inFolder': false,
+        'metaFile': false,
+        'suffix': 'settings',
         'xmlName': 'Settings'
     },
     {


### PR DESCRIPTION
@joeferraro fyi my editor strips out trailing whitespace, you'll want to ignore whitespace when looking at this (real change is just +9-2)

if you have a moment, was curious to get your input on how to let sublime text know that this extension ".md" is supported, i did it locally by editing my user st3 mavenmates setting, but was a bit confused since I thought we were moving away from storing any settings an ST3. should i just update `mm_apex_file_extensions` to include `.md` and call it a day?