### PR TITLE
Support for multi-line debug log entries

### DIFF
--- a/lib/mavensmate/log.js
+++ b/lib/mavensmate/log.js
@@ -96,7 +96,14 @@ LogService.prototype.filter = function(location, keyword) {
         return reject(new Error('Log file not found'))
       }
       var matchingLines = [];
-      var fileLines = fs.readFileSync(location, 'utf8').toString().split(/\r?\n/);
+      /*
+        Matching by the timestamp at the very begining of every log entry.
+        Using positive lookahead (?=) because it doesn't remove the matching string from the returned splits (don't want to actually remove the timestamps).
+        Using the modifiers:
+        - global : Don't return on first match.
+        - multi-line : ^ and $ match the begining and end of each line instead of string only.
+      */
+      var fileLines = fs.readFileSync(location, 'utf8').toString().split(/(?=^\d{2}:\d{2}:\d{2}\.\d+ \(\d+\)\|)/gm);
       var matcher = new RegExp(keyword, 'i');
       _.each(fileLines, function(fl) {
         if (matcher.test(fl)) {


### PR DESCRIPTION
### Example
```apex
System.debug(JSON.serializePretty([ SELECT Id FROM Contact LIMIT 1 ]));
```
### Before
![capture13](https://cloud.githubusercontent.com/assets/14942417/13014527/36bbbc3c-d1ac-11e5-8aa6-5c703d98556f.PNG)

### After
![capture14](https://cloud.githubusercontent.com/assets/14942417/13014533/3b7a21dc-d1ac-11e5-820f-f30b7baa6897.PNG)

### Disclaimer
Cannot guarantee the correctness of the solution:
- am not fluent in regex
- no testing performed:
    - tried only with several debug logs available
    - unskilled to contribute with unit tests

### Credits
[Online regex tester and debugger: JavaScript, Python, PHP, and PCRE](https://regex101.com/)
[Stack Overflow answer by jichi](http://stackoverflow.com/a/25221523)
