### PR TITLE
indexMetadata on refresh or update project

### DIFF
--- a/app/lib/commands/metadata/refresh-metadata.js
+++ b/app/lib/commands/metadata/refresh-metadata.js
@@ -50,6 +50,8 @@ Command.prototype.execute = function() {
         } else {
           return Promise.resolve();
         }
+      }).then( function (){
+        project.indexMetadata();
       })
       .then(function() {
         resolve('Metadata successfully refreshed');

--- a/app/lib/commands/project/edit-project.js
+++ b/app/lib/commands/project/edit-project.js
@@ -44,6 +44,8 @@ Command.prototype.execute = function() {
           } else {
             return Promise.resolve();
           }
+        }).then( function (){
+          self.getProject().indexMetadata();
         })
         .then(function() {
           resolve('Project updated successfully!');


### PR DESCRIPTION
I simple call the Project function *indexMetadata* just before exit the *refresh* and *update* project. That update the *org_metadata* file.

This would close joeferraro/MavensMate#715