### PR TITLE
adding 'prompt=login' to oAuth request to force a login prompt

### DIFF
--- a/app/routes/auth.js
+++ b/app/routes/auth.js
@@ -45,7 +45,8 @@ router.post('/', function(req, res) {
     client_id: process.env.SFDC_OAUTH_CLIENT_ID || '3MVG9uudbyLbNPZP7kLgoRiWVRqiN8gFcKwdAlztVnjgbj9shSk1vMXJNmV7W0ciFbeYiaP9D4tLfBBD06l_7',
     redirect_uri: process.env.SFDC_OAUTH_CALLBACK_URL || 'https://localhost:56248/sfdc/auth/callback',
     response_type: process.env.SFDC_OAUTH_RESPONSE_TYPE || 'token',
-    display: 'popup'
+    display: 'popup',
+    prompt: 'login'
   };
   if (req.body.username) {
     params.login_hint = req.body.username;


### PR DESCRIPTION
Possible fix for #752.   Forces login prompt when adding new project. 
