### PR TITLE
Auth Page: Environment Default Selection

### DIFF
--- a/app/routes/auth.js
+++ b/app/routes/auth.js
@@ -7,6 +7,7 @@ var logger          = require('winston');
 var querystring     = require('querystring');
 var path            = require('path');
 var util            = require('../lib/util');
+var _               = require('lodash');
 
 router.get('/new', function(req, res) {
   var project;
@@ -15,9 +16,25 @@ router.get('/new', function(req, res) {
   } else if (req.query.pid) {
     project = util.getProjectById(req.app, req.query.pid);
   }
+  
+  var envOptions = {
+    production : { name:'Production'},
+    sandbox : { name:'Sandbox'},
+    developer : { name:'Developer'},
+    prerelease : { name:'Prerelease'},
+    custom : { name:'Custom URL'}
+  };
+  
+  var instanceUrl;
+  if(project && project.settings && project.settings.instanceUrl){
+    envOptions.custom.selected = true;
+    instanceUrl = project.settings.instanceUrl;
+  }
 
   res.render('auth/index.html', {
     project: project,
+    envOptions: envOptions,
+    instanceUrl: instanceUrl,
     title: req.query.title,
     callback: req.query.callback,
     param1: req.query.param1,

--- a/app/routes/auth.js
+++ b/app/routes/auth.js
@@ -50,14 +50,21 @@ router.get('/callback', function(req, res) {
 
 router.post('/', function(req, res) {
   var orgType = req.body.orgType;
-  var instanceUrl = req.body.instanceUrl;
-  if (!instanceUrl) {
-    if (orgType === 'sandbox') {
-      instanceUrl = 'https://test.salesforce.com/';
-    } else {
-      instanceUrl = 'https://login.salesforce.com/';
-    }
+  
+  switch(orgType){
+    case 'production':
+    case 'developer':
+    case 'prerelease':
+        instanceUrl = 'https://login.salesforce.com/';
+        break;
+    case 'sandbox':
+        instanceUrl = 'https://test.salesforce.com/';
+        break;  
+    case 'custom':
+        var instanceUrl = req.body.instanceUrl;
+        break;
   }
+
   var params = {
     client_id: process.env.SFDC_OAUTH_CLIENT_ID || '3MVG9uudbyLbNPZP7kLgoRiWVRqiN8gFcKwdAlztVnjgbj9shSk1vMXJNmV7W0ciFbeYiaP9D4tLfBBD06l_7',
     redirect_uri: process.env.SFDC_OAUTH_CALLBACK_URL || 'https://localhost:56248/sfdc/auth/callback',

--- a/app/views/auth/index.html
+++ b/app/views/auth/index.html
@@ -52,12 +52,10 @@
     <label class="slds-form-element__label" for="select-01">Salesforce Environment Type</label>
     <div class="slds-form-element__control">
       <div class="slds-select_container">
-        <select id="orgType" class="slds-select" name="orgType">
-          <option value="production">Production</option>
-          <option value="developer">Developer</option>
-          <option value="sandbox">Sandbox</option>
-          <option value="prerelease">Prerelease</option>
-          <option value="custom">Custom URL</option>
+        <select id="orgType" class="slds-select" name="orgType" >
+        {%for field, opt in envOptions%}
+            <option value="{{field}}" {%if opt.selected %}selected{% endif %}>{{opt.name}}</option>
+        {% endfor %}
         </select>
       </div>
     </div>
@@ -66,7 +64,7 @@
   <div class="slds-form-element" style="display:none;" id="instanceUrlWrapper">
     <label class="slds-form-element__label" for="inputSample2">Salesforce Custom URL</label>
     <div class="slds-form-element__control">
-      <input id="instanceUrl" name="instanceUrl" class="slds-input" type="text" placeholder="Example: https://na1-blitz01.salesforce.com">
+      <input id="instanceUrl" name="instanceUrl" class="slds-input" type="text" value="{{instanceUrl}}" placeholder="Example: https://na1-blitz01.salesforce.com">
     </div>
   </div>
 </form>
@@ -91,6 +89,8 @@
           $('#instanceUrlWrapper').val('');
         }
       });
+
+      $('#orgType').trigger('change');
     });
   </script>
 {% endblock %}


### PR DESCRIPTION
When authenticating a existing project, this will look at the project settings to default the Environment Type Select list.  If type = custom it will also auto-populate the Custom URL field.

I couldn't figure out anything in the settings that indicates if the project is "Developer" or "Prerelease".  The `project.settings.environment` seems to be `undefined` for everything except for 'production' or 'sandbox'.   The code be cleaned up if environment was set for each type.

However, functionally this should at least allow people to login without having to update these settings every-time (since developer and pre-release both use login.salesforce.com). 
