### PR TITLE
Fixed bug (#747) where refresh handshake would fail due to login urls…

### DIFF
--- a/app/lib/sfdc-client.js
+++ b/app/lib/sfdc-client.js
@@ -161,7 +161,8 @@ SalesforceClient.prototype.initialize = function() {
       self.conn = new jsforce.Connection({
         oauth2: {
           clientId : self.clientId,
-          redirectUri : self.callbackUrl
+          redirectUri : self.callbackUrl,
+          loginUrl: self.instanceUrl
         },
         refreshFn: self._refreshFn,
         instanceUrl: self.instanceUrl || 'https://na1.salesforce.com',


### PR DESCRIPTION
Added `loginUrl` param to oAuth2 initialization.  It was being defaulted to production instance, which called the refresh handshake to fail when project was not on Production Env.

Fixes #747 
