### PR TITLE
Fix for 2 vulnerable dependency paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "nconf": "0.6.9",
     "node-uuid": "1.4.1",
     "open": "0.0.3",
-    "request": "2.47.0",
+    "request": "2.74.0",
     "sax": "0.6.1",
     "socket.io": "^1.3.7",
     "strip-json-comments": "1.0.2",


### PR DESCRIPTION
MavensMate currently has a 23 vulnerable dependency paths, introducing 13 different types of known vulnerabilities.

This PR fixes vulnerable dependencies, [remote memory exposure ](https://snyk.io/vuln/npm:request:20160119) vulnerability in the `request` dependency, [ReDos vulnerability](https://snyk.io/vuln/npm:hawk:20160119) in the `hawk` dependency.

You can see [Snyk test report](https://snyk.io/test/github/joeferraro/MavensMate) of this project for details. 

This PR changes `Package.json` to upgrade `request` to the newer 2.74.0 version, and will fix the vulnerability listed above.
You can get alerts and fix PRs for future vulnerabilities for free by [watching this repo with Snyk](https://snyk.io/add).

Note this PR fixes all the vulnerabilities introduced trough `request` dependency, in order to be vulnerability free you will need to upgrade other dependencies as well.

Stay Secure,
The Snyk Team
