### PR TITLE
Fixed a syntax error in the Node Module documentation. It looks like …

### DIFF
--- a/docs/server/module.md
+++ b/docs/server/module.md
@@ -34,7 +34,7 @@ myProject.initialize(true)
 	.then(function(res) {
 		console.log('command result', res);
 	})
-	.catch(function(err)) {
+	.catch(function(err) {
 		console.error('womp', err);
 	});
 ```


### PR DESCRIPTION
Fixed a syntax error in the Node Module documentation. It looks like there was an extra closing parens that would always throw an error if you tried to run this.
