### PR TITLE
check if file is directory when getting test classes #805

### DIFF
--- a/app/routes/test.js
+++ b/app/routes/test.js
@@ -69,6 +69,9 @@ function _getTestClasses(project) {
     fs.readdirSync(classPath).forEach(function(filename) {
       var fileNameParts = path.basename(filename).split('.');
       var fn = fileNameParts[0];
+      if(fs.lstatSync(path.join(classPath, filename)).isDirectory()){
+        return;
+      }
       var fileBody = util.getFileBody(path.join(classPath, filename));
       if (isTestRegEx.test(fileBody) || testMethodRegex.test(fileBody)) {
         classes.push(fn);


### PR DESCRIPTION
Prevents exception from being thrown if user adds directory to /src/classes
