### PR TITLE
#655 Ability to specify TestLevel & Specify tests to run (>=34.0)

### DIFF
--- a/app/lib/services/deploy.js
+++ b/app/lib/services/deploy.js
@@ -31,7 +31,7 @@ var mavensMateFile        = require('../file');
  * @param {Array} opts.sfdcClient - Sfdc Client instance
  * @param {Array} opts.targets - array of org connections
  * @param {Array} opts.checkOnly - whether this is a validate-only deployment
- * @param {Array} opts.runTests - whether to run tests during this deployment
+ * @param {Array.<String>} [opts.runTests] - A list of Apex tests to be run during deployment.
  * @param {Array} opts.rollbackOnError - whether to rollback when the deployment fails
  * @param {Array} opts.package - deployment payload
  * @param {Array} opts.newDeploymentName - the name of the deployment to be saved for future deploys

--- a/app/views/deploy/index.html
+++ b/app/views/deploy/index.html
@@ -98,16 +98,6 @@
 
 				<div class="slds-form-element">
   				<div class="slds-form-element__control">
-  					<label class="slds-checkbox" for="run_tests">
-  					  <input type="checkbox" id="run_tests">
-  					  <span class="slds-checkbox--faux"></span>
-  					  <span class="slds-form-element__label">Run All Tests</span>
-  					</label>
-  				</div>
-				</div>
-
-				<div class="slds-form-element">
-  				<div class="slds-form-element__control">
   					<label class="slds-checkbox" for="ignoreWarnings">
   					  <input type="checkbox" id="ignoreWarnings">
   					  <span class="slds-checkbox--faux"></span>
@@ -116,29 +106,60 @@
   				</div>
 				</div>
 
-  		</fieldset>
+        {% if parseInt(mavensmate.ui.config.get('mm_api_version')) >= 34 %}
+        <div class="slds-form-element">
+          <label class="slds-form-element__label" for="test_level">Test Level</label>
+          <div class="slds-form-element__control">
+            <div class="slds-select_container">
+              <select id="test_level" class="slds-select" name="test_level" >
+                <option value="NoTestRun">No Tests</option>
+                <option value="RunSpecifiedTests">Specified Tests</option>
+                <option value="RunAllTestsInOrg">All Tests</option>
+                <option value="RunLocalTests">Local Tests</option>
+              </select>
+            </div>
+          </div>
+				</div>
 
-  	</div>
-  </div>
-  <div id="tab-default-3" class="slds-tabs--scoped__content slds-hide" role="tabpanel">
-    {% include 'views/partials/metadata_tree.html' %}
-  </div>
-  <div id="tab-default-4" class="slds-tabs--scoped__content slds-hide" role="tabpanel">
-    <div id="deploy-result">
-      <div class="slds-notify slds-notify--toast slds-theme--info" role="alert">
-        <span class="slds-assistive-text">Information</span>
-        <div class="slds-notify__content slds-grid">
-          <svg aria-hidden="true" class="slds-icon slds-icon--small slds-m-right--small slds-col slds-no-flex">
-            <use xlink:href="/app/static/lds/assets/icons/utility-sprite/svg/symbols.svg#info"></use>
-          </svg>
-          <div class="slds-col slds-align-middle">
-            <h2 class="slds-text-heading--small ">Deploy results will display here when available.</h2>
+        <div id="specify_tests_container" class="slds-tabs--scoped__content slds-hide">
+          {% include 'views/partials/test_select.html' %}
+        </div>
+
+        {% else %}
+        <div class="slds-form-element">
+  				<div class="slds-form-element__control">
+  					<label class="slds-checkbox" for="run_tests">
+  					  <input type="checkbox" id="run_tests">
+  					  <span class="slds-checkbox--faux"></span>
+  					  <span class="slds-form-element__label">Run All Tests</span>
+  					</label>
+  				</div>
+				</div>
+        {% endif %}
+
+        </fieldset>
+
+        </div>
+      </div>
+      <div id="tab-default-3" class="slds-tabs--scoped__content slds-hide" role="tabpanel">
+        {% include 'views/partials/metadata_tree.html' %}
+      </div>
+      <div id="tab-default-4" class="slds-tabs--scoped__content slds-hide" role="tabpanel">
+        <div id="deploy-result">
+          <div class="slds-notify slds-notify--toast slds-theme--info" role="alert">
+            <span class="slds-assistive-text">Information</span>
+            <div class="slds-notify__content slds-grid">
+              <svg aria-hidden="true" class="slds-icon slds-icon--small slds-m-right--small slds-col slds-no-flex">
+                <use xlink:href="/app/static/lds/assets/icons/utility-sprite/svg/symbols.svg#info"></use>
+              </svg>
+              <div class="slds-col slds-align-middle">
+                <h2 class="slds-text-heading--small ">Deploy results will display here when available.</h2>
+              </div>
+            </div>
           </div>
         </div>
       </div>
-    </div>
-  </div>
-{% endblock %}
+    {% endblock %}
 
 
 {% block buttons %}
@@ -149,7 +170,7 @@
 
 {% block body_js %}
 <script type="text/javascript">
-	var metadataTree;
+  var metadataTree;
 
   $(function() {
     $('[data-aljs="tabs"]').tabs();
@@ -164,6 +185,14 @@
     $("#check_only").change(function() {
       var text = (this.checked)? 'Validate Deployment' : 'Deploy to Server';
       $("#btnDeploy").html(text);
+    });
+
+    $("#test_level").change(function() {
+      if(showTestSelect()){
+        $('#specify_tests_container').removeClass('slds-hide');
+      }else{
+        $('#specify_tests_container').addClass('slds-hide');
+      }
     });
 
     if (!{{ hasIndexedMetadata }}) {
@@ -191,9 +220,21 @@
 		return $("#check_only").is(":checked");
 	}
 
-	function isRunTests() {
+  function isRunTests() {
 		return $("#run_tests").is(":checked");
 	}
+
+	function getTestLevel() {
+		return $("#test_level").val();
+	}
+
+  function showTestSelect(){
+    return getTestLevel() == 'RunSpecifiedTests';
+  }
+
+  function getRunTests(){
+    return $('#specify_tests').text().split(',');
+  }
 
 	function isRollbackOnError() {
 		return $("#rollback").is(":checked");
@@ -237,6 +278,23 @@
 	}
 
 	function deploy() {
+    var deployOpts = {
+            rollbackOnError: isRollbackOnError(),
+            performRetrieve: true,
+            checkOnly: isValidateOnly(),
+            ignoreWarnings: isIgnoreWarnings()
+    };
+
+    if({{ mavensmate.ui.config.get('mm_api_version') }} >= 34){
+      deployOpts.testLevel = getTestLevel();
+      if(showTestSelect()){
+        deployOpts.runTests = getTestsToRun();
+      }
+    }else{
+      deployOpts.runAllTests = isRunTests();
+    }
+
+
     var opts = {
       showPageHeaderLoading: true,
       ajax: {
@@ -247,13 +305,7 @@
           package: metadataTree.getPackage(),
           deploymentName: $("#new_deployment_name").val(),
           ui: true,
-          deployOptions: {
-            rollbackOnError: isRollbackOnError(),
-            performRetrieve: true,
-            checkOnly: isValidateOnly(),
-            ignoreWarnings: isIgnoreWarnings(),
-            runAllTests: isRunTests()
-          }
+          deployOptions: deployOpts
         })
       }
     };

--- a/app/views/partials/test_select.html
+++ b/app/views/partials/test_select.html
@@ -1,0 +1,107 @@
+{% if testClasses.length > 0 %}
+  <div class="slds-box slds-theme--shade slds-m-bottom--x-small" id="div-test-classes-filter">
+    <div class="slds-grid">
+      <div class="slds-col slds-has-flexi-truncate">
+        <input type="text" placeholder="Search for test classes" id="txt-test-classes-search" class="slds-input" />
+      </div>
+    </div>
+  </div>
+
+  <table id="table-apex-test-classes" class="slds-table slds-table--bordered slds-table--fixed-layout" role="grid">
+    <thead>
+      <tr class="slds-text-heading--label">
+        <td role="gridcell" class="slds-cell-shrink" scope="col">
+          <label class="slds-checkbox">
+            <input type="checkbox" id="chk-select-all-tests" />
+            <span class="slds-checkbox--faux"></span>
+            <span class="slds-assistive-text">Select All</span>
+          </label>
+        </td>
+        <th scope="col">
+          <div class="" title="Class Name">Class Name</div>
+        </th>
+      </tr>
+    </thead>
+    <tbody>
+        {% for cls in testClasses %}
+          <tr class="slds-hint-parent">
+            <td role="gridcell" class="slds-cell-shrink" data-label="Select row Cloudhub">
+              <label class="slds-checkbox">
+                <input type="checkbox" class="chk-run-test-class" data-class-name={{cls}} />
+                <span class="slds-checkbox--faux"></span>
+                <span class="slds-assistive-text">Select row {{cls}}</span>
+              </label>
+            </td>
+            <th scope="row" data-label="{{cls}}">
+              <div class="" title="{{cls}}">{{cls}}</div>
+            </th>
+          </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  {% else %}
+
+    <div class="slds-notify slds-notify--toast slds-theme--warning" role="alert">
+      <span class="slds-assistive-text">Success</span>
+      <div class="slds-notify__content slds-grid">
+        <svg aria-hidden="true" class="slds-icon slds-icon--small slds-m-right--small slds-col slds-no-flex">
+          <use xlink:href="/app/static/lds/assets/icons/utility-sprite/svg/symbols.svg#warning"></use>
+        </svg>
+        <div class="slds-col slds-align-middle">
+          <h2 class="slds-text-heading--small ">MavensMate could not detect any Apex test classes in your project. Use the <a href="/app/project/{{project.settings.id}}/edit?pid={{project.settings.id}}">Edit Project</a> screen to add classes to your project</h2>
+        </div>
+      </div>
+    </div>
+{% endif %}
+
+<script type="text/javascript">
+
+  $('table#table-apex-test-classes > tbody > tr').on('click', function() {
+    var $chkBox = $(this).find('input.chk-run-test-class');
+    $chkBox.prop('checked', !$chkBox.prop('checked'));
+    if ($chkBox.prop('checked')) {
+      $(this).addClass('slds-is-selected');
+    } else {
+      $(this).removeClass('slds-is-selected');
+    }
+  });
+
+  $('input#chk-select-all-tests').on('click', function() {
+    if ($(this).prop('checked')) {
+      $('table#table-apex-test-classes > tbody > tr:not(.invisible) input.chk-run-test-class').prop('checked', true);
+      $('table#table-apex-test-classes > tbody > tr').not('.invisible').removeClass('slds-is-selected').addClass('slds-is-selected');
+    } else {
+      $('table#table-apex-test-classes > tbody > tr:not(.invisible) input.chk-run-test-class').prop('checked', false);
+      $('table#table-apex-test-classes > tbody > tr').not('.invisible').removeClass('slds-is-selected');
+    }
+  });
+
+  $('input#txt-test-classes-search').change(function() {
+    var thevalue = $(this).val().toLowerCase();
+    $('#table-apex-test-classes > tbody > tr > th > div').each(function() {
+        var className = $(this).html().toLowerCase();
+        if (className.indexOf(thevalue) === -1) {
+          $(this).parent().parent().hide().removeClass('invisible').addClass('invisible');
+        } else {
+          $(this).parent().parent().show().removeClass('invisible');
+        }
+    });
+  })
+  .keyup(function() {
+      $(this).change();
+  });
+
+  /*
+	returns an array of test names that are selected
+	 */
+	function getTestsToRun() {
+		var testsToRun = [];
+		$('.chk-run-test-class').each(function() {
+			var $chkbox = $(this);
+			if ($chkbox.attr('checked') === 'checked') {
+				testsToRun.push($chkbox.data('class-name'));
+			}
+		});
+		return testsToRun;
+	}
+</script>

--- a/app/views/partials/test_select.html
+++ b/app/views/partials/test_select.html
@@ -27,7 +27,7 @@
           <tr class="slds-hint-parent">
             <td role="gridcell" class="slds-cell-shrink" data-label="Select row Cloudhub">
               <label class="slds-checkbox">
-                <input type="checkbox" class="chk-run-test-class" data-class-name={{cls}} />
+                <input type="checkbox" {%if className == cls %}checked{% endif %}  class="chk-run-test-class" data-class-name={{cls}} />
                 <span class="slds-checkbox--faux"></span>
                 <span class="slds-assistive-text">Select row {{cls}}</span>
               </label>

--- a/app/views/unit_test/index.html
+++ b/app/views/unit_test/index.html
@@ -7,65 +7,10 @@
       <li class="slds-tabs--scoped__item slds-text-heading--label" title="Apex Test Classes" role="presentation"><a class="slds-tabs--scoped__link" href="#" role="tab" tabindex="0" aria-selected="false" aria-controls="tab-default-1" data-aljs-show="tab-default-1">Apex Test Classes</a></li>
       <li class="slds-tabs--scoped__item slds-text-heading--label" title="Test Results" role="presentation" id="li-test-result"><a class="slds-tabs--scoped__link" href="#" role="tab" tabindex="0" aria-selected="false" aria-controls="tab-default-2" data-aljs-show="tab-default-2">Test Results</a></li>
   </ul>
-  <div id="tab-default-1" class="slds-tabs--scoped__content slds-hide" role="tabpanel">
-  	{% if testClasses.length > 0 %}
+	<div id="tab-default-1" class="slds-tabs--scoped__content slds-hide" role="tabpanel">
+		{% include 'views/partials/test_select.html' %}
+	</div>
 
-  	<div class="slds-box slds-theme--shade slds-m-bottom--x-small" id="div-test-classes-filter">
-  	  <div class="slds-grid">
-  	    <div class="slds-col slds-has-flexi-truncate">
-  	      <input type="text" placeholder="Search for test classes" id="txt-test-classes-search" class="slds-input" />
-  	    </div>
-  	  </div>
-  	</div>
-
-  	<table id="table-apex-test-classes" class="slds-table slds-table--bordered slds-table--fixed-layout" role="grid">
-  	  <thead>
-  	    <tr class="slds-text-heading--label">
-  	    	<td role="gridcell" class="slds-cell-shrink" scope="col">
-		        <label class="slds-checkbox">
-		          <input type="checkbox" id="chk-select-all-tests" />
-		          <span class="slds-checkbox--faux"></span>
-		          <span class="slds-assistive-text">Select All</span>
-		        </label>
-		      </td>
-		      <th scope="col">
-		        <div class="" title="Class Name">Class Name</div>
-		      </th>
-  	    </tr>
-	    </thead>
-	    <tbody>
-		    	{% for cls in testClasses %}
-			    	<tr class="slds-hint-parent">
-			    		<td role="gridcell" class="slds-cell-shrink" data-label="Select row Cloudhub">
-				        <label class="slds-checkbox">
-				          <input type="checkbox" class="chk-run-test-class" data-class-name={{cls}} />
-				          <span class="slds-checkbox--faux"></span>
-				          <span class="slds-assistive-text">Select row {{cls}}</span>
-				        </label>
-				      </td>
-				      <th scope="row" data-label="{{cls}}">
-				      	<div class="" title="{{cls}}">{{cls}}</div>
-				      </th>
-			    	</tr>
-		    {% endfor %}
-	    </tbody>
-    </table>
-    {% else %}
-
-    	<div class="slds-notify slds-notify--toast slds-theme--warning" role="alert">
-    	  <span class="slds-assistive-text">Success</span>
-    	  <div class="slds-notify__content slds-grid">
-    	    <svg aria-hidden="true" class="slds-icon slds-icon--small slds-m-right--small slds-col slds-no-flex">
-    	      <use xlink:href="/app/static/lds/assets/icons/utility-sprite/svg/symbols.svg#warning"></use>
-    	    </svg>
-    	    <div class="slds-col slds-align-middle">
-    	      <h2 class="slds-text-heading--small ">MavensMate could not detect any Apex test classes in your project. Use the <a href="/app/project/{{project.settings.id}}/edit?pid={{project.settings.id}}">Edit Project</a> screen to add classes to your project</h2>
-    	    </div>
-    	  </div>
-    	</div>
-
-    {% endif %}
-  </div>
   <div id="tab-default-2" class="slds-tabs--scoped__content slds-hide" role="tabpanel">
   	<div id="test-result">
   		<div class="slds-notify slds-notify--toast slds-theme--info" role="alert">
@@ -98,41 +43,6 @@
 <script>
 	$(function() {
 		$('[data-aljs="tabs"]').tabs();
-
-		$('table#table-apex-test-classes > tbody > tr').on('click', function() {
-			var $chkBox = $(this).find('input.chk-run-test-class');
-			$chkBox.prop('checked', !$chkBox.prop('checked'));
-			if ($chkBox.prop('checked')) {
-				$(this).addClass('slds-is-selected');
-			} else {
-				$(this).removeClass('slds-is-selected');
-			}
-		});
-
-		$('input#chk-select-all-tests').on('click', function() {
-			if ($(this).prop('checked')) {
-				$('table#table-apex-test-classes > tbody > tr:not(.invisible) input.chk-run-test-class').prop('checked', true);
-				$('table#table-apex-test-classes > tbody > tr').not('.invisible').removeClass('slds-is-selected').addClass('slds-is-selected');
-			} else {
-				$('table#table-apex-test-classes > tbody > tr:not(.invisible) input.chk-run-test-class').prop('checked', false);
-				$('table#table-apex-test-classes > tbody > tr').not('.invisible').removeClass('slds-is-selected');
-			}
-		});
-
-		$('input#txt-test-classes-search').change(function() {
-      var thevalue = $(this).val().toLowerCase();
-      $('#table-apex-test-classes > tbody > tr > th > div').each(function() {
-          var className = $(this).html().toLowerCase();
-          if (className.indexOf(thevalue) === -1) {
-            $(this).parent().parent().hide().removeClass('invisible').addClass('invisible');
-          } else {
-            $(this).parent().parent().show().removeClass('invisible');
-          }
-      });
-    })
-    .keyup(function() {
-       $(this).change();
-    });
 	});
 
 	function showCoverage(a, apexClassOrTriggerName, metadataTypeXmlName, uncoveredLines) {
@@ -212,19 +122,6 @@
 		  });
 	}
 
-	/*
-	returns an array of test names that are selected
-	 */
-	function getTestsToRun() {
-		var testsToRun = [];
-		$('.chk-run-test-class').each(function() {
-			var $chkbox = $(this);
-			if ($chkbox.attr('checked') === 'checked') {
-				testsToRun.push($chkbox.data('class-name'));
-			}
-		});
-		return testsToRun;
-	}
 </script>
 
 {% endblock %}


### PR DESCRIPTION
#655 
Ability to specify Test Level 
- backwards compatible (new functionality only shows when API version set to `>= 34.0`)
- User can select tests to run
- Moved Test Selection to partial view and refactored `view/unit_test.html` to remain DRY

<img width="1328" alt="mavensmate___debug_testing___deploy" src="https://cloud.githubusercontent.com/assets/5217568/19918902/b6b45360-a094-11e6-954b-e815ae245c96.png">
